### PR TITLE
Fix PHP 7.4 compatibility

### DIFF
--- a/includes/class-dashboard-glancer.php
+++ b/includes/class-dashboard-glancer.php
@@ -119,7 +119,7 @@ class Dashboard_Glancer {
 	 */
 	protected function get_single_item( array $item ) {
 		$num_posts = wp_count_posts( $item['type'] );
-		$count = $num_posts->$item['status'];
+		$count = $num_posts->{$item['status']};
 
 		if ( ! $count ) {
 			return '';


### PR DESCRIPTION
Fixes the following PHP 7.4 compatibility issue:
```
Error in plugins/documentation-post-type/includes/class-dashboard-glancer.php: Indirect access to variables, properties and methods will be evaluated strictly in left-to-right order since PHP 7.0. Use curly braces to remove ambiguity.
```